### PR TITLE
fix, wont extract thumbnail

### DIFF
--- a/PicImageSearch/model/google.py
+++ b/PicImageSearch/model/google.py
@@ -26,7 +26,7 @@ class GoogleResponse:
         self.raw: List[GoogleItem] = [
             GoogleItem(
                 i,
-                (thumbnail_dict[i("img").attr("id")] if i("img").attr("id") else None),
+                (thumbnail_dict[i("img").eq(1).attr("id")] if i("img").eq(1).attr("id") else None),
             )
             for i in data.items()
         ]


### PR DESCRIPTION
Cause?? Google add favicon on their search result, this made scrapper wont able extract the image id, because there are two image elements