### PR TITLE
Update yandex.py

### DIFF
--- a/PicImageSearch/yandex.py
+++ b/PicImageSearch/yandex.py
@@ -40,7 +40,7 @@ class Yandex(HandOver):
         Raises:
             ValueError: If neither 'url' nor 'file' is provided.
         """
-        params = {"rpt": "imageview"}
+        params = {"rpt": "imageview", "cbir_page": "sites"}
         if url:
             params["url"] = url
             resp = await self.get(BASE_URL, params=params)


### PR DESCRIPTION
a new item has been added to the parameters, which increases the number of returned results by going directly to the “sites” page and not “about the image”
before:
![image](https://github.com/kitUIN/PicImageSearch/assets/135450017/1c26b7a3-7b3a-4a09-ba29-0bd00a6f2d3f)
![image](https://github.com/kitUIN/PicImageSearch/assets/135450017/876a7a7c-a0c2-415d-80eb-cc2aa9545712)

after:
![image](https://github.com/kitUIN/PicImageSearch/assets/135450017/ad435554-e734-4656-8bb1-5e83995f794e)
![image](https://github.com/kitUIN/PicImageSearch/assets/135450017/467cfd95-c192-4dfc-85ed-b8a38c140862)


