### PR TITLE
add parsing copyseeker.net

### DIFF
--- a/demo/code/copyseeker.py
+++ b/demo/code/copyseeker.py
@@ -1,15 +1,17 @@
 import asyncio
+
 from loguru import logger
-from src import Network, Copyseeker
+
+from src import Copyseeker, Network
 from src.model import CopyseekerResponse
 from src.sync import Copyseeker as CopyseekerSync
 
 # proxies = "http://127.0.0.1:1081"
 proxies = None
-url = "https://github.com/kitUIN/PicImageSearch/blob/main/demo/images/test05.jpg?raw=true"
+url = (
+    "https://github.com/kitUIN/PicImageSearch/blob/main/demo/images/test05.jpg?raw=true"
+)
 file = "../images/test05.jpg"
-
-
 
 
 @logger.catch()
@@ -24,26 +26,30 @@ async def test_async() -> None:
 @logger.catch()
 def test_sync() -> None:
     copyseeker = CopyseekerSync(proxies=proxies)
-    # resp = copyseeker.search(url=url)
-    resp = asyncio.run(copyseeker.search(file=file))
-    show_result(resp) # type: ignore
+    resp = copyseeker.search(url=url)
+    # resp = copyseeker.search(file=file)
+    show_result(resp)  # type: ignore
 
 
 def show_result(resp: CopyseekerResponse) -> None:
-    logger.info(resp.bestGuessLabel)
-    logger.info(resp.totalLinksFound)
+    logger.info(resp.id)
+    logger.info(resp.image_url)
+    logger.info(resp.best_guess_label)
+    logger.info(resp.entities)
+    logger.info(resp.total)
+    logger.info(resp.exif)
+    logger.info(resp.similar_image_urls)
     if resp.raw:
         logger.info(resp.raw[0].url)
         logger.info(resp.raw[0].title)
-        logger.info(resp.raw[0].rank)
-        logger.info(resp.raw[0].mainImage)
-        logger.info(resp.raw[0].otherImages)
+        logger.info(resp.raw[0].website_rank)
+        logger.info(resp.raw[0].thumbnail)
+        logger.info(resp.raw[0].thumbnail_list)
     logger.info("-" * 50)
     # logger.info(resp.visuallySimilarImages)
 
 
-
 if __name__ == "__main__":
-    # loop = asyncio.get_event_loop()
-    # loop.run_until_complete(test_async())
-    test_sync()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(test_async())
+    # test_sync()

--- a/demo/code/copyseeker.py
+++ b/demo/code/copyseeker.py
@@ -1,0 +1,49 @@
+import asyncio
+from loguru import logger
+from src import Network, Copyseeker
+from src.model import CopyseekerResponse
+from src.sync import Copyseeker as CopyseekerSync
+
+# proxies = "http://127.0.0.1:1081"
+proxies = None
+url = "https://github.com/kitUIN/PicImageSearch/blob/main/demo/images/test05.jpg?raw=true"
+file = "../images/test05.jpg"
+
+
+
+
+@logger.catch()
+async def test_async() -> None:
+    async with Network(proxies=proxies) as client:
+        copyseeker = Copyseeker(client=client)
+        # resp = await copyseeker.search(url=url)
+        resp = await copyseeker.search(file=file)
+        show_result(resp)
+
+
+@logger.catch()
+def test_sync() -> None:
+    copyseeker = CopyseekerSync(proxies=proxies)
+    # resp = copyseeker.search(url=url)
+    resp = asyncio.run(copyseeker.search(file=file))
+    show_result(resp) # type: ignore
+
+
+def show_result(resp: CopyseekerResponse) -> None:
+    logger.info(resp.bestGuessLabel)
+    logger.info(resp.totalLinksFound)
+    if resp.raw:
+        logger.info(resp.raw[0].url)
+        logger.info(resp.raw[0].title)
+        logger.info(resp.raw[0].rank)
+        logger.info(resp.raw[0].mainImage)
+        logger.info(resp.raw[0].otherImages)
+    logger.info("-" * 50)
+    # logger.info(resp.visuallySimilarImages)
+
+
+
+if __name__ == "__main__":
+    # loop = asyncio.get_event_loop()
+    # loop.run_until_complete(test_async())
+    test_sync()

--- a/src/engines/__init__.py
+++ b/src/engines/__init__.py
@@ -1,21 +1,21 @@
 from .ascii2d import Ascii2D
 from .baidu import BaiDu
+from .copyseeker import Copyseeker
 from .ehentai import EHentai
 from .google import Google
 from .iqdb import Iqdb
 from .saucenao import SauceNAO
 from .tracemoe import TraceMoe
 from .yandex import Yandex
-from .copyseeker import Copyseeker
 
 __all__ = [
     "Ascii2D",
     "BaiDu",
+    "Copyseeker",
     "EHentai",
     "Google",
     "Iqdb",
     "SauceNAO",
     "TraceMoe",
     "Yandex",
-    "Copyseeker",
 ]

--- a/src/engines/__init__.py
+++ b/src/engines/__init__.py
@@ -6,6 +6,7 @@ from .iqdb import Iqdb
 from .saucenao import SauceNAO
 from .tracemoe import TraceMoe
 from .yandex import Yandex
+from .copyseeker import Copyseeker
 
 __all__ = [
     "Ascii2D",
@@ -16,4 +17,5 @@ __all__ = [
     "SauceNAO",
     "TraceMoe",
     "Yandex",
+    "Copyseeker",
 ]

--- a/src/engines/copyseeker.py
+++ b/src/engines/copyseeker.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import os
+from json import loads as json_loads
+
+from ..model import CopyseekerItem, CopyseekerResponse
+from ..utils import read_file
+from .base import BaseSearchEngine
+
+class Copyseeker(BaseSearchEngine):
+    """API client for the Copyseeker image search engine.
+
+    Used for performing reverse image searches using Copyseeker service.
+
+    Attributes:
+        base_url: The base URL for Copyseeker searches.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://api.copyseeker.net",
+        **request_kwargs: Any
+    ):
+        """Initializes a Copyseeker API client.
+
+        Args:
+            base_url: The base URL for Copyseeker searches.
+            **request_kwargs: Additional arguments for network requests.
+        """
+        super().__init__(base_url, **request_kwargs)
+
+
+    async def _get_discovery_id(
+        self,
+        url: Optional[str] = None,
+        file: Union[str, bytes, Path, None] = None
+    ):
+
+        if url:
+            payload = {
+                "imageUrl": url,
+                "discoveryType": "ReverseImageSearch"
+            }
+            resp = await self._make_request(method="post", endpoint="OnTriggerDiscoveryByUrl", json=payload)
+        elif file:
+            files = {"file": read_file(file)}
+            resp = await self._make_request(
+                method="post",
+                endpoint="OnTriggerDiscoveryByFile",
+                files=files,
+                data={"discoveryType": "ReverseImageSearch"}
+            )
+        else:
+            raise ValueError("Either 'url' or 'file' must be provided")
+
+        json_response = json_loads(resp.text)
+        return json_response.get("discoveryId")
+        
+
+
+    async def search(
+        self,
+        url: Optional[str] = None,
+        file: Union[str, bytes, Path, None] = None, **kwargs: Any
+    ) -> CopyseekerResponse:
+        
+        await super().search(url, file, **kwargs)
+
+        discovery_id = await self._get_discovery_id(url, file)
+        if discovery_id is None:
+            return CopyseekerResponse({}, "")
+
+        data = {
+            "discoveryId": discovery_id,
+            "hasBlocker": False
+        }
+
+        resp = await self._make_request(method="post", endpoint="OnProvideDiscovery", json=data)
+        resp_json = json_loads(resp.text)
+        return CopyseekerResponse(resp_json, resp.url)

--- a/src/engines/copyseeker.py
+++ b/src/engines/copyseeker.py
@@ -1,12 +1,11 @@
+from json import loads as json_loads
 from pathlib import Path
 from typing import Any, Optional, Union
 
-import os
-from json import loads as json_loads
-
-from ..model import CopyseekerItem, CopyseekerResponse
+from ..model import CopyseekerResponse
 from ..utils import read_file
 from .base import BaseSearchEngine
+
 
 class Copyseeker(BaseSearchEngine):
     """API client for the Copyseeker image search engine.
@@ -18,9 +17,7 @@ class Copyseeker(BaseSearchEngine):
     """
 
     def __init__(
-        self,
-        base_url: str = "https://api.copyseeker.net",
-        **request_kwargs: Any
+        self, base_url: str = "https://api.copyseeker.net", **request_kwargs: Any
     ):
         """Initializes a Copyseeker API client.
 
@@ -30,52 +27,66 @@ class Copyseeker(BaseSearchEngine):
         """
         super().__init__(base_url, **request_kwargs)
 
-
     async def _get_discovery_id(
-        self,
-        url: Optional[str] = None,
-        file: Union[str, bytes, Path, None] = None
+        self, url: Optional[str] = None, file: Union[str, bytes, Path, None] = None
     ):
 
+        data = {"discoveryType": "ReverseImageSearch"}
+
         if url:
-            payload = {
-                "imageUrl": url,
-                "discoveryType": "ReverseImageSearch"
-            }
-            resp = await self._make_request(method="post", endpoint="OnTriggerDiscoveryByUrl", json=payload)
+            data["imageUrl"] = url
+            resp = await self._make_request(
+                method="post",
+                endpoint="OnTriggerDiscoveryByUrl",
+                json=data,
+            )
         elif file:
             files = {"file": read_file(file)}
             resp = await self._make_request(
                 method="post",
                 endpoint="OnTriggerDiscoveryByFile",
+                data=data,
                 files=files,
-                data={"discoveryType": "ReverseImageSearch"}
             )
-        else:
-            raise ValueError("Either 'url' or 'file' must be provided")
 
-        json_response = json_loads(resp.text)
-        return json_response.get("discoveryId")
-        
-
+        resp_json = json_loads(resp.text)  # noqa
+        return resp_json.get("discoveryId")
 
     async def search(
         self,
         url: Optional[str] = None,
-        file: Union[str, bytes, Path, None] = None, **kwargs: Any
+        file: Union[str, bytes, Path, None] = None,
+        **kwargs: Any,
     ) -> CopyseekerResponse:
-        
+        """Performs a reverse image search on Copyseeker.
+
+        Supports searching by image URL or by uploading an image file.
+
+        Requires either 'url' or 'file' to be provided.
+
+        Args:
+            url: URL of the image to search.
+            file: Local image file (path or bytes) to search.
+
+        Returns:
+            CopyseekerResponse: Contains search results and additional information.
+
+        Raises:
+            ValueError: If neither 'url' nor 'file' is provided.
+
+        Note:
+            The search process involves multiple HTTP requests to Copyseeker's API.
+        """
         await super().search(url, file, **kwargs)
 
         discovery_id = await self._get_discovery_id(url, file)
         if discovery_id is None:
             return CopyseekerResponse({}, "")
 
-        data = {
-            "discoveryId": discovery_id,
-            "hasBlocker": False
-        }
+        data = {"discoveryId": discovery_id, "hasBlocker": False}
 
-        resp = await self._make_request(method="post", endpoint="OnProvideDiscovery", json=data)
+        resp = await self._make_request(
+            method="post", endpoint="OnProvideDiscovery", json=data
+        )
         resp_json = json_loads(resp.text)
         return CopyseekerResponse(resp_json, resp.url)

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,9 +1,9 @@
 from .ascii2d import Ascii2DItem, Ascii2DResponse
 from .baidu import BaiDuItem, BaiDuResponse
+from .copyseeker import CopyseekerItem, CopyseekerResponse
 from .ehentai import EHentaiItem, EHentaiResponse
 from .google import GoogleItem, GoogleResponse
 from .iqdb import IqdbItem, IqdbResponse
 from .saucenao import SauceNAOItem, SauceNAOResponse
 from .tracemoe import TraceMoeItem, TraceMoeMe, TraceMoeResponse
 from .yandex import YandexItem, YandexResponse
-from .copyseeker import CopyseekerItem, CopyseekerResponse

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -6,3 +6,4 @@ from .iqdb import IqdbItem, IqdbResponse
 from .saucenao import SauceNAOItem, SauceNAOResponse
 from .tracemoe import TraceMoeItem, TraceMoeMe, TraceMoeResponse
 from .yandex import YandexItem, YandexResponse
+from .copyseeker import CopyseekerItem, CopyseekerResponse

--- a/src/model/copyseeker.py
+++ b/src/model/copyseeker.py
@@ -1,0 +1,72 @@
+from typing import Any, Optional
+from .base import BaseSearchItem, BaseSearchResponse
+
+
+
+class CopyseekerItem(BaseSearchItem):
+    """Represents a single Copyseeker search result item.
+
+    Holds details of a result from a Copyseeker reverse image search.
+
+    Attributes:
+        origin: The raw data of the search result item.
+        url: URL of the webpage with the image.
+        title: Title of the webpage.
+        mainImage: URL of the main image on the page.
+        otherImages: List of URLs of other images on the page.
+        rank: Rank or similarity score of the result.
+    """
+    def __init__(self, data: dict[str, Any], **kwargs: Any):
+        """Initializes a CopyseekerItem with data from a search result.
+
+        Args:
+            data: A dictionary containing the search result data.
+        """
+        super().__init__(data, **kwargs)
+        
+    def _parse_data(self, data: dict[str, Any], **kwargs) -> None:
+
+        self.url: str = data["url"]
+        self.title: str = data["title"]
+        self.mainImage: str = data.get("mainImage", "")
+        self.otherImages: list[str] = data.get("otherImages", []) # Corrected type hint
+        self.rank: float = data.get("rank", 0.0)
+
+
+
+class CopyseekerResponse(BaseSearchResponse):
+    """Encapsulates a Copyseeker reverse image search response.
+
+    Contains the complete response from a Copyseeker reverse image search operation.
+
+    Attributes:
+        id: Unique identifier for the search request.
+        imageUrl: URL of the image searched.
+        bestGuessLabel: Copyseeker's best guess for the image category.
+        entities: Entities detected in the image.
+        totalLinksFound: Total number of links found.
+        exif: EXIF data extracted from the image.
+        raw: List of CopyseekerItem objects, each representing a search result.
+        visuallySimilarImages: List of URLs of visually similar images.
+        url: URL of the Copyseeker search results page.
+    """
+
+    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs):
+        """Initializes with the response data.
+
+        Args:
+            resp_data: A dictionary containing the parsed response data from Copyseeker.
+            resp_url: URL to the search result page.
+        """
+        super().__init__(resp_data, resp_url, **kwargs)
+
+    def _parse_response(self, resp_data: dict[str, Any], **kwargs) -> None:
+        """Parse search response data."""
+        self.id: str = resp_data["id"]
+        self.imageUrl: str = resp_data["imageUrl"]
+        self.bestGuessLabel: Optional[str] = resp_data.get("bestGuessLabel")
+        self.entities: Optional[str] = resp_data.get("entities")
+        self.totalLinksFound: int = resp_data["totalLinksFound"]
+        self.exif: dict[str, Any] = resp_data.get("exif", {})
+        self.raw: list[CopyseekerItem] = [CopyseekerItem(page) for page in resp_data.get("pages", [])]
+        self.visuallySimilarImages: list[str] = resp_data.get("visuallySimilarImages", [])

--- a/src/model/copyseeker.py
+++ b/src/model/copyseeker.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
-from .base import BaseSearchItem, BaseSearchResponse
 
+from .base import BaseSearchItem, BaseSearchResponse
 
 
 class CopyseekerItem(BaseSearchItem):
@@ -12,10 +12,11 @@ class CopyseekerItem(BaseSearchItem):
         origin: The raw data of the search result item.
         url: URL of the webpage with the image.
         title: Title of the webpage.
-        mainImage: URL of the main image on the page.
-        otherImages: List of URLs of other images on the page.
-        rank: Rank or similarity score of the result.
+        thumbnail: URL of the thumbnail image.
+        thumbnail_list: List of URLs of thumbnail images.
+        website_rank: Website rank of the result.
     """
+
     def __init__(self, data: dict[str, Any], **kwargs: Any):
         """Initializes a CopyseekerItem with data from a search result.
 
@@ -23,15 +24,14 @@ class CopyseekerItem(BaseSearchItem):
             data: A dictionary containing the search result data.
         """
         super().__init__(data, **kwargs)
-        
+
     def _parse_data(self, data: dict[str, Any], **kwargs) -> None:
 
         self.url: str = data["url"]
         self.title: str = data["title"]
-        self.mainImage: str = data.get("mainImage", "")
-        self.otherImages: list[str] = data.get("otherImages", []) # Corrected type hint
-        self.rank: float = data.get("rank", 0.0)
-
+        self.thumbnail: str = data.get("mainImage", "")
+        self.thumbnail_list: list[str] = data.get("otherImages", [])
+        self.website_rank: float = data.get("rank", 0.0)
 
 
 class CopyseekerResponse(BaseSearchResponse):
@@ -41,13 +41,13 @@ class CopyseekerResponse(BaseSearchResponse):
 
     Attributes:
         id: Unique identifier for the search request.
-        imageUrl: URL of the image searched.
-        bestGuessLabel: Copyseeker's best guess for the image category.
+        image_url: URL of the image searched.
+        best_guess_label: Copyseeker's best guess for the image category.
         entities: Entities detected in the image.
-        totalLinksFound: Total number of links found.
+        total: Total number of links found.
         exif: EXIF data extracted from the image.
         raw: List of CopyseekerItem objects, each representing a search result.
-        visuallySimilarImages: List of URLs of visually similar images.
+        similar_image_urls: List of URLs of visually similar images.
         url: URL of the Copyseeker search results page.
     """
 
@@ -63,10 +63,12 @@ class CopyseekerResponse(BaseSearchResponse):
     def _parse_response(self, resp_data: dict[str, Any], **kwargs) -> None:
         """Parse search response data."""
         self.id: str = resp_data["id"]
-        self.imageUrl: str = resp_data["imageUrl"]
-        self.bestGuessLabel: Optional[str] = resp_data.get("bestGuessLabel")
+        self.image_url: str = resp_data["imageUrl"]
+        self.best_guess_label: Optional[str] = resp_data.get("bestGuessLabel")
         self.entities: Optional[str] = resp_data.get("entities")
-        self.totalLinksFound: int = resp_data["totalLinksFound"]
+        self.total: int = resp_data["totalLinksFound"]
         self.exif: dict[str, Any] = resp_data.get("exif", {})
-        self.raw: list[CopyseekerItem] = [CopyseekerItem(page) for page in resp_data.get("pages", [])]
-        self.visuallySimilarImages: list[str] = resp_data.get("visuallySimilarImages", [])
+        self.raw: list[CopyseekerItem] = [
+            CopyseekerItem(page) for page in resp_data.get("pages", [])
+        ]
+        self.similar_image_urls: list[str] = resp_data.get("visuallySimilarImages", [])

--- a/src/sync.py
+++ b/src/sync.py
@@ -9,7 +9,7 @@ import asyncio
 import functools
 import inspect
 
-from . import Ascii2D, BaiDu, EHentai, Google, Iqdb, Network, SauceNAO, TraceMoe, Yandex
+from . import Ascii2D, BaiDu, EHentai, Google, Iqdb, Network, SauceNAO, TraceMoe, Yandex, Copyseeker
 
 
 def _syncify_wrap(class_type, method_name):  # type: ignore
@@ -67,4 +67,5 @@ __all__ = [
     "SauceNAO",
     "TraceMoe",
     "Yandex",
+    "Copyseeker",
 ]

--- a/src/sync.py
+++ b/src/sync.py
@@ -9,7 +9,18 @@ import asyncio
 import functools
 import inspect
 
-from . import Ascii2D, BaiDu, EHentai, Google, Iqdb, Network, SauceNAO, TraceMoe, Yandex, Copyseeker
+from . import (
+    Ascii2D,
+    BaiDu,
+    Copyseeker,
+    EHentai,
+    Google,
+    Iqdb,
+    Network,
+    SauceNAO,
+    TraceMoe,
+    Yandex,
+)
 
 
 def _syncify_wrap(class_type, method_name):  # type: ignore
@@ -55,11 +66,12 @@ def syncify(*classes):  # type: ignore
                 _syncify_wrap(c, name)  # type: ignore
 
 
-syncify(Ascii2D, BaiDu, EHentai, Google, Iqdb, Network, SauceNAO, TraceMoe, Yandex)  # type: ignore
+syncify(Ascii2D, BaiDu, Copyseeker, EHentai, Google, Iqdb, Network, SauceNAO, TraceMoe, Yandex)  # type: ignore
 
 __all__ = [
     "Ascii2D",
     "BaiDu",
+    "Copyseeker",
     "EHentai",
     "Google",
     "Iqdb",
@@ -67,5 +79,4 @@ __all__ = [
     "SauceNAO",
     "TraceMoe",
     "Yandex",
-    "Copyseeker",
 ]


### PR DESCRIPTION
This pull request adds the copyseeker.net engine

How the parsing itself works:
We use the site's hidden API. First, we send a request to `https://api.copyseeker.net/OnTriggerDiscoveryByFile` (or URL), receive a discoveryId, which we then need to get the search results via the link `https://api.copyseeker.net/OnProvideDiscovery`
(By the way, it might be possible to parse Bing using a similar method, but I haven't tried it yet)

Let's move straight to the drawbacks.
1. To parse this site, we have to make two requests.
First to `https://api.copyseeker.net/OnTriggerDiscoveryByFile` (or URL), and then to `https://api.copyseeker.net/OnProvideDiscovery`.
As tests have shown, the first request (for the discoveryId) gets a quick response, while the second (result) is slow.
Unfortunately, I couldn't find another way to parse this site. And it's unlikely that a different parsing method exists.

2. I couldn't understand why in the file demo/code/copyseeker.py it gives an error without asyncio.run() in the test_sync() function. I couldn't fix this, although I wrote the code based on other engines.

3. There might be a lot of "Novice-level code" here, as I'm not very familiar with Python, which might require a lot of corrections.