### PR TITLE
add engine(Tineye)

### DIFF
--- a/PicImageSearch/engines/__init__.py
+++ b/PicImageSearch/engines/__init__.py
@@ -6,6 +6,7 @@ from .ehentai import EHentai
 from .google import Google
 from .iqdb import Iqdb
 from .saucenao import SauceNAO
+from .tineye import Tineye
 from .tracemoe import TraceMoe
 from .yandex import Yandex
 
@@ -18,6 +19,7 @@ __all__ = [
     "Google",
     "Iqdb",
     "SauceNAO",
+    "Tineye",
     "TraceMoe",
     "Yandex",
 ]

--- a/PicImageSearch/engines/ascii2d.py
+++ b/PicImageSearch/engines/ascii2d.py
@@ -6,7 +6,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class Ascii2D(BaseSearchEngine):
+class Ascii2D(BaseSearchEngine[Ascii2DResponse]):
     """API client for the Ascii2D image search engine.
 
     Ascii2D provides two search modes:
@@ -78,16 +78,15 @@ class Ascii2D(BaseSearchEngine):
             - Only one of `url` or `file` should be provided
             - Feature search (bovw) may take longer to process
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         data: Optional[dict[str, Any]] = None
         files: Optional[dict[str, Any]] = None
+        endpoint: str = "uri" if url else "file"
 
         if url:
-            endpoint = "uri"
             data = {"uri": url}
-        else:
-            endpoint = "file"
+        elif file:
             files = {"file": read_file(file)}
 
         resp = await self._make_request(

--- a/PicImageSearch/engines/baidu.py
+++ b/PicImageSearch/engines/baidu.py
@@ -10,7 +10,7 @@ from ..utils import deep_get, read_file
 from .base import BaseSearchEngine
 
 
-class BaiDu(BaseSearchEngine):
+class BaiDu(BaseSearchEngine[BaiDuResponse]):
     """API client for the BaiDu image search engine.
 
     Used for performing reverse image searches using BaiDu service.
@@ -91,14 +91,14 @@ class BaiDu(BaseSearchEngine):
             - The search process involves multiple HTTP requests to BaiDu's API.
             - The response format varies depending on whether matches are found.
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         params = {"from": "pc"}
         files: Optional[dict[str, Any]] = None
 
         if url:
             params["image"] = url
-        else:
+        elif file:
             files = {"image": read_file(file)}
 
         resp = await self._make_request(

--- a/PicImageSearch/engines/base.py
+++ b/PicImageSearch/engines/base.py
@@ -1,12 +1,15 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from ..model.base import BaseSearchResponse
 from ..network import HandOver
 
+ResponseT = TypeVar("ResponseT")
+T = TypeVar("T", bound=BaseSearchResponse[Any])
 
-class BaseSearchEngine(HandOver, ABC):
+
+class BaseSearchEngine(HandOver, ABC, Generic[T]):
     """Base search engine class providing common functionality for all reverse image search engines.
 
     This abstract base class implements the core functionality shared by all image search engines,
@@ -36,7 +39,7 @@ class BaseSearchEngine(HandOver, ABC):
         url: Optional[str] = None,
         file: Union[str, bytes, Path, None] = None,
         **kwargs: Any,
-    ) -> BaseSearchResponse:  # type: ignore
+    ) -> T:
         """Perform a reverse image search.
 
         This abstract method must be implemented by all search engine classes.
@@ -51,11 +54,24 @@ class BaseSearchEngine(HandOver, ABC):
             **kwargs (Any): Additional search parameters specific to each search engine.
 
         Returns:
-            BaseSearchResponse: Search results. The specific return type depends on the implementing class.
+            T: Search results. The specific return type depends on the implementing class.
 
         Raises:
             ValueError: If neither 'url' nor 'file' is provided.
             NotImplementedError: If the method is not implemented by the subclass.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _validate_args(url: Optional[str], file: Union[str, bytes, Path, None]) -> None:
+        """Validate the arguments for the search method.
+
+        Args:
+            url (Optional[str]): URL of the image to search.
+            file (Union[str, bytes, Path, None]): Local image file to search.
+
+        Raises:
+            ValueError: If neither 'url' nor 'file' is provided.
         """
         if not url and not file:
             raise ValueError("Either 'url' or 'file' must be provided")

--- a/PicImageSearch/engines/copyseeker.py
+++ b/PicImageSearch/engines/copyseeker.py
@@ -7,7 +7,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class Copyseeker(BaseSearchEngine):
+class Copyseeker(BaseSearchEngine[CopyseekerResponse]):
     """API client for the Copyseeker image search engine.
 
     Used for performing reverse image searches using Copyseeker service.
@@ -56,7 +56,7 @@ class Copyseeker(BaseSearchEngine):
                 endpoint="OnTriggerDiscoveryByUrl",
                 json=data,
             )
-        else:
+        elif file:
             files = {"file": read_file(file)}
             resp = await self._make_request(
                 method="post",
@@ -65,8 +65,8 @@ class Copyseeker(BaseSearchEngine):
                 files=files,
             )
 
-        resp_json = json_loads(resp.text)  # noqa
-        return resp_json.get("discoveryId")
+        resp_json = json_loads(resp.text)
+        return resp_json.get("discoveryId")  # type: ignore
 
     async def search(
         self,
@@ -100,7 +100,7 @@ class Copyseeker(BaseSearchEngine):
             - Only one of `url` or `file` should be provided.
             - The search process involves multiple HTTP requests to Copyseeker's API.
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         discovery_id = await self._get_discovery_id(url, file)
         if discovery_id is None:

--- a/PicImageSearch/engines/ehentai.py
+++ b/PicImageSearch/engines/ehentai.py
@@ -6,7 +6,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class EHentai(BaseSearchEngine):
+class EHentai(BaseSearchEngine[EHentaiResponse]):
     """API client for the EHentai image search engine.
 
     Used for performing reverse image searches using EHentai service.
@@ -80,14 +80,15 @@ class EHentai(BaseSearchEngine):
             - For ExHentai searches, valid cookies must be provided in the request_kwargs.
             - Search behavior is affected by the covers, similar, and exp flags set during initialization.
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         endpoint = "upld/image_lookup.php" if self.is_ex else "image_lookup.php"
         data: dict[str, Any] = {"f_sfile": "File Search"}
+        files: dict[str, Any] = {}
 
         if url:
-            files: dict[str, Any] = {"sfile": await self.download(url)}
-        else:
+            files = {"sfile": await self.download(url)}
+        elif file:
             files = {"sfile": read_file(file)}
 
         if self.covers:

--- a/PicImageSearch/engines/google.py
+++ b/PicImageSearch/engines/google.py
@@ -6,7 +6,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class Google(BaseSearchEngine):
+class Google(BaseSearchEngine[GoogleResponse]):
     """API client for the Google image search engine.
 
     Used for performing reverse image searches using Google service.
@@ -55,6 +55,7 @@ class Google(BaseSearchEngine):
         next_page_number = resp.page_number + offset
         if next_page_number < 1 or next_page_number > len(resp.pages):
             return None
+
         _resp = await self.get(resp.pages[next_page_number - 1])
         return GoogleResponse(_resp.text, _resp.url, next_page_number, resp.pages)
 
@@ -142,14 +143,14 @@ class Google(BaseSearchEngine):
             - The method automatically ensures thumbnail data is present in results
             - Safe search is disabled by default
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         params: dict[str, Any] = {"sbisrc": 1, "safe": "off"}
 
         if url:
             params["image_url"] = url
             resp = await self._make_request(method="get", params=params)
-        else:
+        elif file:
             files = {"encoded_image": read_file(file)}
             resp = await self._make_request(
                 method="post",

--- a/PicImageSearch/engines/iqdb.py
+++ b/PicImageSearch/engines/iqdb.py
@@ -6,7 +6,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class Iqdb(BaseSearchEngine):
+class Iqdb(BaseSearchEngine[IqdbResponse]):
     """API client for the Iqdb image search engine.
 
     A client implementation for performing reverse image searches using Iqdb's services.
@@ -70,7 +70,7 @@ class Iqdb(BaseSearchEngine):
                 - is_3d=True: Searches real-life images on 3d.iqdb.org
             - The force_gray option can help find visually similar images regardless of coloring
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         data: dict[str, Any] = {}
         files: Optional[dict[str, Any]] = None
@@ -80,7 +80,7 @@ class Iqdb(BaseSearchEngine):
 
         if url:
             data["url"] = url
-        else:
+        elif file:
             files = {"file": read_file(file)}
 
         resp = await self._make_request(

--- a/PicImageSearch/engines/saucenao.py
+++ b/PicImageSearch/engines/saucenao.py
@@ -9,7 +9,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class SauceNAO(BaseSearchEngine):
+class SauceNAO(BaseSearchEngine[SauceNAOResponse]):
     """API client for the SauceNAO image search engine.
 
     Used for performing reverse image searches using SauceNAO service.
@@ -119,14 +119,14 @@ class SauceNAO(BaseSearchEngine):
                 * 4 searches per 30 seconds
             - Results are sorted by similarity score in descending order.
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         params = self.params
         files: Optional[dict[str, Any]] = None
 
         if url:
             params = params.add("url", url)
-        else:
+        elif file:
             files = {"file": read_file(file)}
 
         resp = await self._make_request(

--- a/PicImageSearch/engines/tineye.py
+++ b/PicImageSearch/engines/tineye.py
@@ -182,6 +182,6 @@ class Tineye(BaseSearchEngine[TineyeResponse]):
         if query_hash := deep_get(resp_json, "query.key"):
             query_string = "&".join(f"{k}={v}" for k, v in params.items())
             _url = f"{self.base_url}/search/{query_hash}?{query_string}"
-            domains = await self._get_domains(query_hash)
+            domains = await self._get_domains(deep_get(resp_json, "query.hash"))
 
         return TineyeResponse(resp_json, _url, domains)

--- a/PicImageSearch/engines/tineye.py
+++ b/PicImageSearch/engines/tineye.py
@@ -1,0 +1,179 @@
+import mimetypes
+from json import loads as json_loads
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from ..model import TineyeResponse
+from ..utils import read_file
+from .base import BaseSearchEngine
+
+
+class Tineye(BaseSearchEngine):
+    """API client for the Tineye reverse image search engine.
+
+    Tineye is a reverse image search engine that allows you to find where an image appears on the web.
+    This client provides methods for searching by image URL or by uploading a local image file,
+    and retrieving matching images along with their domains and counts.
+
+    Attributes:
+        base_url (str): The base URL for Tineye searches. Defaults to "https://tineye.com".
+    """
+
+    def __init__(self, base_url: str = "https://tineye.com", **request_kwargs: Any):
+        """Initializes a Tineye API client.
+
+        Args:
+            base_url (str): The base URL for Tineye searches.
+            **request_kwargs (Any): Additional keyword arguments passed to the underlying network client.
+        """
+        super().__init__(base_url, **request_kwargs)
+
+
+    async def _get_domains(self, query_hash: str) -> dict[str, int]:
+        """Retrieves domain information for a given query hash.
+
+        Args:
+            query_hash (str): The unique identifier for the search query.
+
+        Returns:
+            list[str, int, str]: A list mapping domains to the count of matching images found on that domain. list[domain, count, tag(stock or collection)]
+        """
+
+        resp = await self._make_request(
+            method="get", endpoint=f"api/v1/search/get_domains/{query_hash}"
+        )
+        resp_json = json_loads(resp.text)
+
+        domains = []
+        for domain_data in resp_json.get('domains', []):
+            domain_name, count, tag = domain_data
+            if len(tag) > 0:
+                tag = tag[0]
+            else:
+                tag = ''
+            domains.append([domain_name, count, tag])
+
+        return domains
+
+
+
+    async def _navigate_page(
+        self, resp: TineyeResponse, offset: int
+    ) -> Optional[TineyeResponse]:
+        """Navigates to a specific page in the Tineye search results.
+
+        This internal method handles the pagination of Tineye results.  It calculates the URL for the target page
+        based on the initial query parameters and fetches the results.
+
+        Args:
+            resp (TineyeResponse): The current `TineyeResponse` object containing pagination information.
+            offset (int): The number of pages to move forward or backward. Positive values move forward,
+                negative values move backward.
+
+        Returns:
+            Optional[TineyeResponse]: A new `TineyeResponse` object for the target page, or `None` if the target page
+                is out of bounds (less than 1 or greater than the total number of pages).
+        """
+        next_page_number = resp.page_number + offset
+        if next_page_number < 1 or next_page_number > len(resp.pages):
+            return None
+
+        _resp = await self.get(resp.pages[next_page_number - 1])
+        resp_json = json_loads(_resp.text)
+        resp_json.update({"status_code": _resp.status_code})
+
+        return TineyeResponse(
+            resp_json, _resp.url, next_page_number, resp.pages, resp.query_hash, domains=resp.domains
+        )
+
+
+    async def pre_page(self, resp: TineyeResponse) -> Optional[TineyeResponse]:
+        """Navigates to the previous page of Tineye search results.
+
+        Args:
+            resp (TineyeResponse): The current `TineyeResponse` object.
+
+        Returns:
+            Optional[TineyeResponse]: A `TineyeResponse` object for the previous page, or `None` if there is no
+                previous page.
+        """
+        return await self._navigate_page(resp, -1)
+
+    async def next_page(self, resp: TineyeResponse) -> Optional[TineyeResponse]:
+        """Navigates to the next page of Tineye search results.
+
+        Args:
+            resp (TineyeResponse): The current `TineyeResponse` object.
+
+        Returns:
+            Optional[TineyeResponse]: A `TineyeResponse` object for the next page, or `None` if there is no next page.
+        """
+        return await self._navigate_page(resp, 1)
+
+    async def search(
+        self,
+        url: Optional[str] = None,
+        file: Union[str, bytes, Path, None] = None,
+        show_unavailable_domains: bool = False,
+        domain: str = "",
+        sort: str = "score",
+        order: str = "desc",
+        tags: str = "",
+        **kwargs: Any,
+    ) -> TineyeResponse:
+        """Performs a reverse image search on Tineye.
+
+        Searches for matching images on the web using either an image URL or a local image file.
+        After the initial search, retrieves domain information for the matched images.
+
+
+        Args:
+            url (Optional[str]): The URL of the image to search for.
+            file (Union[str, bytes, Path, None]): The local path to the image file to search for.
+            show_unavailable_domains (bool): Whether to include results from unavailable domains. Defaults to False.
+            domain (str):  Filter results to only include matches from this domain (only one domain is allowed). Defaults to "".
+            sort (str): The sorting criteria for results. Can be "size", "score", or "crawl_date". Defaults to "score".
+                - "score" (with `order="desc"`): Best match first (default).
+                - "score" (with `order="asc"`): Most changed first.
+                - "crawl_date" (with `order="desc"`): Newest images first.
+                - "crawl_date" (with `order="asc"`): Oldest images first.
+                - "size" (with `order="desc"`): Largest images first.
+            order (str): The sorting order. Can be "asc" (ascending) or "desc" (descending). Defaults to "desc".
+            tags (str):  Comma-separated tags to filter results. For example, "stock,collection". Defaults to "".
+            **kwargs (Any): Additional keyword arguments passed to the underlying network client.
+
+        Returns:
+            TineyeResponse: A `TineyeResponse` object containing the search results, domain information, and metadata.
+
+        Raises:
+            ValueError: If neither `url` nor `file` is provided.
+        """
+        await super().search(url, file, **kwargs)
+        files: Optional[dict[str, Any]] = None
+        data: dict[str, Any] = {
+            "sort": sort,
+            "order": order,
+            "page": 1,
+            "show_unavailable_domains": True if show_unavailable_domains else '',
+            "tags": tags,
+            "domain": domain,
+        }
+
+        if url:
+            data["url"] = url
+        else:
+            image_path = Path(file) if isinstance(file, (str, Path)) else "image.unknown"
+            with open(file, "rb") as image_file:
+                file_content = image_file.read()
+            content_type, _ = mimetypes.guess_type(str(image_path))
+            files = {
+                "image": (image_path.name, file_content, content_type),
+            }
+        resp = await self._make_request(method="post", endpoint="api/v1/result_json/", data=data, files=files)
+        resp_json = json_loads(resp.text)
+        resp_json.update({"status_code": resp.status_code})
+
+        hash = resp_json['query']['hash']
+        tineye_response = TineyeResponse(resp_json, resp.url, **data)
+        tineye_response.domains = await self._get_domains(hash)
+        return tineye_response

--- a/PicImageSearch/engines/yandex.py
+++ b/PicImageSearch/engines/yandex.py
@@ -6,7 +6,7 @@ from ..utils import read_file
 from .base import BaseSearchEngine
 
 
-class Yandex(BaseSearchEngine):
+class Yandex(BaseSearchEngine[YandexResponse]):
     """API client for the Yandex reverse image search engine.
 
     This class provides an interface to perform reverse image searches using Yandex's service.
@@ -64,14 +64,14 @@ class Yandex(BaseSearchEngine):
             - When using file upload, the image will be sent to Yandex's servers.
             - The search process involves standard Yandex parameters like `rpt` and `cbir_page`.
         """
-        await super().search(url, file, **kwargs)
+        self._validate_args(url, file)
 
         params = {"rpt": "imageview", "cbir_page": "sites"}
 
         if url:
             params["url"] = url
             resp = await self._make_request(method="get", params=params)
-        else:
+        elif file:
             files = {"upfile": read_file(file)}
             resp = await self._make_request(
                 method="post",

--- a/PicImageSearch/model/__init__.py
+++ b/PicImageSearch/model/__init__.py
@@ -6,6 +6,7 @@ from .ehentai import EHentaiItem, EHentaiResponse
 from .google import GoogleItem, GoogleResponse
 from .iqdb import IqdbItem, IqdbResponse
 from .saucenao import SauceNAOItem, SauceNAOResponse
+from .tineye import TineyeItem, TineyeResponse
 from .tracemoe import TraceMoeItem, TraceMoeMe, TraceMoeResponse
 from .yandex import YandexItem, YandexResponse
 
@@ -26,6 +27,8 @@ __all__ = [
     "IqdbResponse",
     "SauceNAOItem",
     "SauceNAOResponse",
+    "TineyeItem",
+    "TineyeResponse",
     "TraceMoeItem",
     "TraceMoeMe",
     "TraceMoeResponse",

--- a/PicImageSearch/model/ascii2d.py
+++ b/PicImageSearch/model/ascii2d.py
@@ -37,7 +37,7 @@ class Ascii2DItem(BaseSearchItem):
         author_url (str): URL to the author's profile page.
     """
 
-    def __init__(self, data: PyQuery, **kwargs):
+    def __init__(self, data: PyQuery, **kwargs: Any) -> None:
         """Initializes an Ascii2DItem with data from a search result.
 
         Args:
@@ -45,7 +45,7 @@ class Ascii2DItem(BaseSearchItem):
         """
         super().__init__(data, **kwargs)
 
-    def _parse_data(self, data: PyQuery, **kwargs) -> None:
+    def _parse_data(self, data: PyQuery, **kwargs: Any) -> None:
         """Parses raw search result data into structured attributes.
 
         Extracts and processes various pieces of information from the PyQuery data,
@@ -175,7 +175,7 @@ class Ascii2DItem(BaseSearchItem):
             self.url_list = [URL(self.url, links.eq(0).text())]
 
 
-class Ascii2DResponse(BaseSearchResponse):
+class Ascii2DResponse(BaseSearchResponse[Ascii2DItem]):
     """Represents a complete Ascii2D reverse image search response.
 
     Processes and contains all search results from an Ascii2D search operation.

--- a/PicImageSearch/model/baidu.py
+++ b/PicImageSearch/model/baidu.py
@@ -14,7 +14,7 @@ class BaiDuItem(BaseSearchItem):
         url (str): URL of the webpage containing the original image.
     """
 
-    def __init__(self, data: dict[str, Any], **kwargs):
+    def __init__(self, data: dict[str, Any], **kwargs: Any) -> None:
         """Initialize a BaiDu search result item.
 
         Args:
@@ -23,7 +23,7 @@ class BaiDuItem(BaseSearchItem):
         """
         super().__init__(data, **kwargs)
 
-    def _parse_data(self, data: dict[str, Any], **kwargs) -> None:
+    def _parse_data(self, data: dict[str, Any], **kwargs: Any) -> None:
         """Parse the raw search result data into structured attributes.
 
         Args:
@@ -42,7 +42,7 @@ class BaiDuItem(BaseSearchItem):
         self.url: str = data["fromUrl"]
 
 
-class BaiDuResponse(BaseSearchResponse):
+class BaiDuResponse(BaseSearchResponse[BaiDuItem]):
     """Encapsulates a complete BaiDu reverse image search response.
 
     A class that handles and stores the full response from a BaiDu reverse image search,
@@ -54,7 +54,7 @@ class BaiDuResponse(BaseSearchResponse):
         url (str): URL of the search results page on BaiDu.
     """
 
-    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs):
+    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs: Any):
         """Initialize a BaiDu search response.
 
         Args:
@@ -64,7 +64,7 @@ class BaiDuResponse(BaseSearchResponse):
         """
         super().__init__(resp_data, resp_url, **kwargs)
 
-    def _parse_response(self, resp_data: dict[str, Any], **kwargs) -> None:
+    def _parse_response(self, resp_data: dict[str, Any], **kwargs: Any) -> None:
         """Parse the raw response data into a list of search result items.
 
         Args:

--- a/PicImageSearch/model/base.py
+++ b/PicImageSearch/model/base.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
 
 
 class BaseSearchItem(ABC):
@@ -44,7 +46,7 @@ class BaseSearchItem(ABC):
         pass
 
 
-class BaseSearchResponse(ABC):
+class BaseSearchResponse(ABC, Generic[T]):
     """Base class for search response handling.
 
     This class serves as a template for processing and storing search results
@@ -66,7 +68,7 @@ class BaseSearchResponse(ABC):
         """
         self.origin: Any = resp_data
         self.url: str = resp_url
-        self.raw: list[BaseSearchItem] = []
+        self.raw: list[T] = []
         self._parse_response(resp_data, resp_url=resp_url, **kwargs)
 
     @abstractmethod

--- a/PicImageSearch/model/bing.py
+++ b/PicImageSearch/model/bing.py
@@ -14,7 +14,15 @@ class BingItem(BaseSearchItem):
         image_url (str): Direct URL to the full-size image.
     """
 
-    def _parse_data(self, data: dict[str, Any], **kwargs) -> None:
+    def __init__(self, data: dict[str, Any], **kwargs: Any):
+        """Initializes a BingItem with data from a search result.
+
+        Args:
+            data (dict[str, Any]): A dictionary containing the search result data.
+        """
+        super().__init__(data, **kwargs)
+
+    def _parse_data(self, data: dict[str, Any], **kwargs: Any) -> None:
         """Parse search result data."""
         self.title: str = data.get("name", "")
         self.url: str = data.get("hostPageUrl", "")
@@ -159,7 +167,7 @@ class EntityItem:
         )
 
 
-class BingResponse(BaseSearchResponse):
+class BingResponse(BaseSearchResponse[BingItem]):
     """Encapsulates the complete response from a Bing reverse image search.
 
     This class processes and organizes various types of information returned by Bing's
@@ -181,6 +189,16 @@ class BingResponse(BaseSearchResponse):
         identifies in the searched image. Not all attributes will contain data
         for every search.
     """
+
+    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs: Any):
+        """Initialize a Bing search response.
+
+        Args:
+            resp_data (dict[str, Any]): The raw JSON response from Bing's API.
+            resp_url (str): The URL of the search results page.
+            **kwargs (Any): Additional keyword arguments passed to the parent class.
+        """
+        super().__init__(resp_data, resp_url, **kwargs)
 
     def _parse_response(self, resp_data: dict[str, Any], **kwargs: Any) -> None:
         """Parse search response data."""

--- a/PicImageSearch/model/copyseeker.py
+++ b/PicImageSearch/model/copyseeker.py
@@ -25,7 +25,7 @@ class CopyseekerItem(BaseSearchItem):
         """
         super().__init__(data, **kwargs)
 
-    def _parse_data(self, data: dict[str, Any], **kwargs) -> None:
+    def _parse_data(self, data: dict[str, Any], **kwargs: Any) -> None:
 
         self.url: str = data["url"]
         self.title: str = data["title"]
@@ -34,7 +34,7 @@ class CopyseekerItem(BaseSearchItem):
         self.website_rank: float = data.get("rank", 0.0)
 
 
-class CopyseekerResponse(BaseSearchResponse):
+class CopyseekerResponse(BaseSearchResponse[CopyseekerItem]):
     """Encapsulates a complete Copyseeker reverse image search response.
 
     Provides a structured interface to access and analyze the search results
@@ -58,7 +58,7 @@ class CopyseekerResponse(BaseSearchResponse):
             not when searching with an image URL.
     """
 
-    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs):
+    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs: Any) -> None:
         """Initializes with the response data.
 
         Args:
@@ -67,7 +67,7 @@ class CopyseekerResponse(BaseSearchResponse):
         """
         super().__init__(resp_data, resp_url, **kwargs)
 
-    def _parse_response(self, resp_data: dict[str, Any], **kwargs) -> None:
+    def _parse_response(self, resp_data: dict[str, Any], **kwargs: Any) -> None:
         """Parse search response data."""
         self.id: str = resp_data["id"]
         self.image_url: str = resp_data["imageUrl"]

--- a/PicImageSearch/model/ehentai.py
+++ b/PicImageSearch/model/ehentai.py
@@ -27,7 +27,7 @@ class EHentaiItem(BaseSearchItem):
         """
         super().__init__(data, **kwargs)
 
-    def _parse_data(self, data: PyQuery, **kwargs) -> None:
+    def _parse_data(self, data: PyQuery, **kwargs: Any) -> None:
         """Initialize and parse the gallery data from search results.
 
         Args:
@@ -72,7 +72,7 @@ class EHentaiItem(BaseSearchItem):
         ]
 
 
-class EHentaiResponse(BaseSearchResponse):
+class EHentaiResponse(BaseSearchResponse[EHentaiItem]):
     """Represents the complete response from an e-hentai reverse image search.
 
     This class processes and organizes the search results from e-hentai,

--- a/PicImageSearch/model/google.py
+++ b/PicImageSearch/model/google.py
@@ -28,14 +28,14 @@ class GoogleItem(BaseSearchItem):
         """
         super().__init__(data, thumbnail=thumbnail)
 
-    def _parse_data(self, data: PyQuery, **kwargs) -> None:
+    def _parse_data(self, data: PyQuery, **kwargs: Any) -> None:
         """Parse search result data."""
         self.title: str = data("h3").text()
         self.url: str = data("a").eq(0).attr("href")
-        self.thumbnail: Optional[str] = kwargs.get("thumbnail")
+        self.thumbnail: Optional[str] = kwargs.get("thumbnail")  # type: ignore
 
 
-class GoogleResponse(BaseSearchResponse):
+class GoogleResponse(BaseSearchResponse[GoogleItem]):
     """Encapsulates a Google reverse image search response.
 
     Processes and stores the complete response from a Google reverse image search,
@@ -70,7 +70,7 @@ class GoogleResponse(BaseSearchResponse):
         """Parse search response data."""
         data = parse_html(resp_data)
         self.origin: PyQuery = data
-        self.page_number: int = kwargs.get("page_number")
+        self.page_number: int = kwargs["page_number"]
 
         if pages := kwargs.get("pages"):
             self.pages: list[str] = pages
@@ -79,7 +79,7 @@ class GoogleResponse(BaseSearchResponse):
                 f'https://www.google.com{i.attr("href")}'
                 for i in data.find('a[aria-label~="Page"]').items()
             ]
-            self.pages.insert(0, kwargs.get("resp_url"))
+            self.pages.insert(0, kwargs["resp_url"])
 
         script_list = list(data.find("script").items())
         thumbnail_dict: dict[str, str] = self.create_thumbnail_dict(script_list)

--- a/PicImageSearch/model/iqdb.py
+++ b/PicImageSearch/model/iqdb.py
@@ -28,7 +28,7 @@ class IqdbItem(BaseSearchItem):
         """
         super().__init__(data, **kwargs)
 
-    def _parse_data(self, data: PyQuery, **kwargs) -> None:
+    def _parse_data(self, data: PyQuery, **kwargs: Any) -> None:
         """Initialize and parse the search result data.
 
         Args:
@@ -95,7 +95,7 @@ class IqdbItem(BaseSearchItem):
         return url if url.startswith("http") else f"https:{url}"
 
 
-class IqdbResponse(BaseSearchResponse):
+class IqdbResponse(BaseSearchResponse[IqdbItem]):
     """Represents a complete IQDB reverse image search response.
 
     Attributes:

--- a/PicImageSearch/model/saucenao.py
+++ b/PicImageSearch/model/saucenao.py
@@ -179,7 +179,7 @@ class SauceNAOItem(BaseSearchItem):
         return str(data.get("author_url", ""))
 
 
-class SauceNAOResponse(BaseSearchResponse):
+class SauceNAOResponse(BaseSearchResponse[SauceNAOItem]):
     """Encapsulates a complete SauceNAO API response.
 
     This class processes and structures the full response from a SauceNAO search,
@@ -203,7 +203,7 @@ class SauceNAOResponse(BaseSearchResponse):
         url (str): URL to view the search results on SauceNAO website.
     """
 
-    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs):
+    def __init__(self, resp_data: dict[str, Any], resp_url: str, **kwargs: Any) -> None:
         """Initializes with the response data.
 
         Args:
@@ -212,7 +212,7 @@ class SauceNAOResponse(BaseSearchResponse):
         """
         super().__init__(resp_data, resp_url, **kwargs)
 
-    def _parse_response(self, resp_data: dict[str, Any], **kwargs) -> None:
+    def _parse_response(self, resp_data: dict[str, Any], **kwargs: Any) -> None:
         """Parse search response data."""
         self.status_code: int = resp_data["status_code"]
         header = resp_data["header"]

--- a/PicImageSearch/model/tineye.py
+++ b/PicImageSearch/model/tineye.py
@@ -1,10 +1,13 @@
-from typing import Any, Optional
+from typing import Any
 
+from ..types import DomainInfo
 from .base import BaseSearchItem, BaseSearchResponse
 
 
 class TineyeItem(BaseSearchItem):
     """Represents a single Tineye search result item.
+
+    A class that processes and stores individual search result data from Tineye reverse image search.
 
     Attributes:
         thumbnail (str): URL of the thumbnail image.
@@ -14,6 +17,14 @@ class TineyeItem(BaseSearchItem):
         size (list[int]): Dimensions of the image as [width, height].
         crawl_date (str): Timestamp indicating when the image was crawled by Tineye.
     """
+
+    def __init__(self, data: dict[str, Any], **kwargs: Any):
+        """Initializes a TineyeItem with data from a search result.
+
+        Args:
+            data (dict[str, Any]): A dictionary containing the search result data.
+        """
+        super().__init__(data, **kwargs)
 
     def _parse_data(self, data: dict[str, Any], **kwargs: Any) -> None:
         """Parses the raw data for a single Tineye search result."""
@@ -25,7 +36,7 @@ class TineyeItem(BaseSearchItem):
         self.crawl_date: str = data["backlinks"][0]["crawl_date"]
 
 
-class TineyeResponse(BaseSearchResponse):
+class TineyeResponse(BaseSearchResponse[TineyeItem]):
     """Represents a complete Tineye search response.
 
     Attributes:
@@ -35,62 +46,37 @@ class TineyeResponse(BaseSearchResponse):
             and values are the number of matches found on that domain. Only available after the initial search.
         query_hash (str): Unique identifier for the search query. Used for pagination.
         status_code (int): HTTP status code of the response.
-        pages (list[str]): URLs of all paginated result pages.
         page_number (int): Current page number.
         url (str): URL of the initial search results page.
-        show_unavailable_domains (bool): Whether unavailable domains are included in results.
     """
 
     def __init__(
         self,
         resp_data: dict[str, Any],
         resp_url: str,
+        domains: list[DomainInfo],
         page_number: int = 1,
-        pages: Optional[list[str]] = None,
-        query_hash: Optional[str] = None,
-        show_unavailable_domains: bool = False,
-        domains: Optional[dict[str, int]] = None,
-        **kwargs,
     ):
-        """Initializes a TineyeResponse object with response data and metadata."""
-        self.query_hash = query_hash
-        self.show_unavailable_domains = True if show_unavailable_domains else False
+        """Initializes a TineyeResponse object with response data and metadata.
+
+        Args:
+            resp_data (dict[str, Any]):
+            resp_url (str):
+            page_number (int):
+        """
+        super().__init__(
+            resp_data,
+            resp_url,
+            domains=domains,
+            page_number=page_number,
+        )
         self.domains = domains
-        super().__init__(resp_data, resp_url, page_number=page_number, pages=pages, **kwargs)
+        self.page_number = page_number
 
     def _parse_response(self, resp_data: dict[str, Any], **kwargs: Any) -> None:
         """Parses the raw JSON response from Tineye."""
-        self.query_hash: str = resp_data.get("query_hash")
-        self.status_code: int = resp_data.get("status_code")
-
-        if pages := kwargs.get("pages"):
-            self.pages = pages
-        else:
-            if self.show_unavailable_domains:
-                num_matches = resp_data.get('num_matches')
-            elif domain := kwargs.get("domain"):
-                num_matches = resp_data.get('num_filtered_matches')
-            else:
-                num_matches = resp_data.get('num_matches', 0) - resp_data.get('num_unavailable_matches', 0)
-            total_pages = int(-1 * num_matches // 10 * -1)
-
-            params = {
-                'tags': kwargs.get("tags", ""),
-                'show_unavailable_domains': True if self.show_unavailable_domains else '',
-                'domain': kwargs.get("domain", ""),
-                'sort': kwargs.get("sort", "score"),
-                'order': kwargs.get("order", "desc"),
-                'page': 1
-            }
-
-            filtered_params = {k: v for k, v in params.items() if v}
-            base_url = f'https://tineye.com/api/v1/result_json/{self.query_hash}'
-            self.pages = []
-            for i in range(1, total_pages + 1):
-                filtered_params['page'] = i
-                self.pages.append(base_url + '?' + '&'.join(f'{k}={v}' for k, v in filtered_params.items()))
-
-
-        self.page_number: int = kwargs.get("page_number", 1)
-        matches = resp_data.get('matches')
-        self.raw: list[TineyeItem] = [TineyeItem(i) for i in matches] if matches else []
+        self.query_hash: str = resp_data["query_hash"]
+        self.status_code: int = resp_data["status_code"]
+        self.total_pages: int = resp_data["total_pages"]
+        matches = resp_data["matches"]
+        self.raw = [TineyeItem(i) for i in matches] if matches else []

--- a/PicImageSearch/model/tineye.py
+++ b/PicImageSearch/model/tineye.py
@@ -1,0 +1,96 @@
+from typing import Any, Optional
+
+from .base import BaseSearchItem, BaseSearchResponse
+
+
+class TineyeItem(BaseSearchItem):
+    """Represents a single Tineye search result item.
+
+    Attributes:
+        thumbnail (str): URL of the thumbnail image.
+        image_url (str): Direct URL to the full-size image.
+        url (str): URL of the webpage where the image was found (backlink).
+        domain (str): Domain of the webpage.
+        size (list[int]): Dimensions of the image as [width, height].
+        crawl_date (str): Timestamp indicating when the image was crawled by Tineye.
+    """
+
+    def _parse_data(self, data: dict[str, Any], **kwargs: Any) -> None:
+        """Parses the raw data for a single Tineye search result."""
+        self.thumbnail: str = data["image_url"]
+        self.image_url: str = data["backlinks"][0]["url"]
+        self.url: str = data["backlinks"][0]["backlink"]
+        self.domain: str = data["domain"]
+        self.size: list[int] = [data["width"], data["height"]]
+        self.crawl_date: str = data["backlinks"][0]["crawl_date"]
+
+
+class TineyeResponse(BaseSearchResponse):
+    """Represents a complete Tineye search response.
+
+    Attributes:
+        origin (dict): The raw JSON response data from Tineye.
+        raw (list[TineyeItem]): List of TineyeItem objects, each representing a search result.
+        domains (dict[str, int]):  A dictionary where keys are the domains where the image was found,
+            and values are the number of matches found on that domain. Only available after the initial search.
+        query_hash (str): Unique identifier for the search query. Used for pagination.
+        status_code (int): HTTP status code of the response.
+        pages (list[str]): URLs of all paginated result pages.
+        page_number (int): Current page number.
+        url (str): URL of the initial search results page.
+        show_unavailable_domains (bool): Whether unavailable domains are included in results.
+    """
+
+    def __init__(
+        self,
+        resp_data: dict[str, Any],
+        resp_url: str,
+        page_number: int = 1,
+        pages: Optional[list[str]] = None,
+        query_hash: Optional[str] = None,
+        show_unavailable_domains: bool = False,
+        domains: Optional[dict[str, int]] = None,
+        **kwargs,
+    ):
+        """Initializes a TineyeResponse object with response data and metadata."""
+        self.query_hash = query_hash
+        self.show_unavailable_domains = True if show_unavailable_domains else False
+        self.domains = domains
+        super().__init__(resp_data, resp_url, page_number=page_number, pages=pages, **kwargs)
+
+    def _parse_response(self, resp_data: dict[str, Any], **kwargs: Any) -> None:
+        """Parses the raw JSON response from Tineye."""
+        self.query_hash: str = resp_data.get("query_hash")
+        self.status_code: int = resp_data.get("status_code")
+
+        if pages := kwargs.get("pages"):
+            self.pages = pages
+        else:
+            if self.show_unavailable_domains:
+                num_matches = resp_data.get('num_matches')
+            elif domain := kwargs.get("domain"):
+                num_matches = resp_data.get('num_filtered_matches')
+            else:
+                num_matches = resp_data.get('num_matches', 0) - resp_data.get('num_unavailable_matches', 0)
+            total_pages = int(-1 * num_matches // 10 * -1)
+
+            params = {
+                'tags': kwargs.get("tags", ""),
+                'show_unavailable_domains': True if self.show_unavailable_domains else '',
+                'domain': kwargs.get("domain", ""),
+                'sort': kwargs.get("sort", "score"),
+                'order': kwargs.get("order", "desc"),
+                'page': 1
+            }
+
+            filtered_params = {k: v for k, v in params.items() if v}
+            base_url = f'https://tineye.com/api/v1/result_json/{self.query_hash}'
+            self.pages = []
+            for i in range(1, total_pages + 1):
+                filtered_params['page'] = i
+                self.pages.append(base_url + '?' + '&'.join(f'{k}={v}' for k, v in filtered_params.items()))
+
+
+        self.page_number: int = kwargs.get("page_number", 1)
+        matches = resp_data.get('matches')
+        self.raw: list[TineyeItem] = [TineyeItem(i) for i in matches] if matches else []

--- a/PicImageSearch/model/tracemoe.py
+++ b/PicImageSearch/model/tracemoe.py
@@ -95,7 +95,7 @@ class TraceMoeItem(BaseSearchItem):
         """
         self.anime_info: dict[str, Any] = {}
         self.idMal: int = 0
-        self.title: dict[str, str] = {}
+        self.title: dict[str, str] = {}  # type: ignore
         self.title_native: str = ""
         self.title_english: str = ""
         self.title_romaji: str = ""
@@ -125,7 +125,7 @@ class TraceMoeItem(BaseSearchItem):
             self.video += "&mute"
 
 
-class TraceMoeResponse(BaseSearchResponse):
+class TraceMoeResponse(BaseSearchResponse[TraceMoeItem]):
     """Represents the complete response from a TraceMoe search operation.
 
     Encapsulates the entire search response including all matched scenes and metadata
@@ -171,13 +171,12 @@ class TraceMoeResponse(BaseSearchResponse):
         Note:
             The parsed results are stored in the `raw` attribute as TraceMoeItem instances.
         """
-        self.raw: list[TraceMoeItem] = []
         res_docs = resp_data["result"]
         self.raw.extend(
             [
                 TraceMoeItem(
                     i,
-                    mute=kwargs.get("mute"),
+                    mute=kwargs.get("mute", False),
                     size=kwargs.get("size"),
                 )
                 for i in res_docs

--- a/PicImageSearch/model/yandex.py
+++ b/PicImageSearch/model/yandex.py
@@ -56,7 +56,7 @@ class YandexItem(BaseSearchItem):
         self.size: str = f"{original_image['width']}x{original_image['height']}"
 
 
-class YandexResponse(BaseSearchResponse):
+class YandexResponse(BaseSearchResponse[YandexItem]):
     """Encapsulates a complete Yandex reverse image search response.
 
     Processes and stores the full response from a Yandex reverse image search,
@@ -77,7 +77,7 @@ class YandexResponse(BaseSearchResponse):
         """
         super().__init__(resp_data, resp_url, **kwargs)
 
-    def _parse_response(self, resp_data: str, **kwargs) -> None:
+    def _parse_response(self, resp_data: str, **kwargs: Any) -> None:
         """Parses the raw HTML response from Yandex into structured data.
 
         Extracts search results from the HTML response by locating and parsing

--- a/PicImageSearch/sync.py
+++ b/PicImageSearch/sync.py
@@ -19,6 +19,7 @@ from . import (
     Iqdb,
     Network,
     SauceNAO,
+    Tineye,
     TraceMoe,
     Yandex,
 )
@@ -67,7 +68,7 @@ def syncify(*classes):  # type: ignore
                 _syncify_wrap(c, name)  # type: ignore
 
 
-syncify(Ascii2D, BaiDu, Bing, Copyseeker, EHentai, Google, Iqdb, Network, SauceNAO, TraceMoe, Yandex)  # type: ignore
+syncify(Ascii2D, BaiDu, Bing, Copyseeker, EHentai, Google, Iqdb, Network, SauceNAO, Tineye, TraceMoe, Yandex)  # type: ignore
 
 __all__ = [
     "Ascii2D",
@@ -79,6 +80,7 @@ __all__ = [
     "Iqdb",
     "Network",
     "SauceNAO",
+    "Tineye",
     "TraceMoe",
     "Yandex",
 ]

--- a/PicImageSearch/sync.py
+++ b/PicImageSearch/sync.py
@@ -68,7 +68,20 @@ def syncify(*classes):  # type: ignore
                 _syncify_wrap(c, name)  # type: ignore
 
 
-syncify(Ascii2D, BaiDu, Bing, Copyseeker, EHentai, Google, Iqdb, Network, SauceNAO, Tineye, TraceMoe, Yandex)  # type: ignore
+syncify(  # type: ignore
+    Ascii2D,
+    BaiDu,
+    Bing,
+    Copyseeker,
+    EHentai,
+    Google,
+    Iqdb,
+    Network,
+    SauceNAO,
+    Tineye,
+    TraceMoe,
+    Yandex,
+)
 
 __all__ = [
     "Ascii2D",

--- a/PicImageSearch/types.py
+++ b/PicImageSearch/types.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+
+
+class DomainTag(str, Enum):
+    """Domain tag types"""
+
+    STOCK = "stock"
+    COLLECTION = "collection"
+
+
+@dataclass
+class DomainInfo:
+    """Domain information structure"""
+
+    domain: str
+    count: int
+    tag: Optional[DomainTag] = None
+
+    @classmethod
+    def from_raw_data(cls, data: list[Any]) -> "DomainInfo":
+        """Create DomainInfo from raw API response data"""
+        domain_name = str(data[0])
+        count = int(data[1])
+        tag = DomainTag(data[2][0]) if data[2] else None
+        return cls(domain=domain_name, count=count, tag=tag)

--- a/README.cn.md
+++ b/README.cn.md
@@ -39,6 +39,7 @@
 | Google     | <https://www.google.com/imghp>       |
 | IQDB       | <https://iqdb.org/>                  |
 | SauceNAO   | <https://saucenao.com/>              |
+| Tineye     | <https://tineye.com/search/>         |
 | TraceMoe   | <https://trace.moe/>                 |
 | Yandex     | <https://yandex.com/images/search>   |
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -39,6 +39,7 @@
 | Google     | <https://www.google.com/imghp>       |
 | IQDB       | <https://iqdb.org/>                  |
 | SauceNAO   | <https://saucenao.com/>              |
+| Tineye     | <https://tineye.com/search/>         |
 | TraceMoe   | <https://trace.moe/>                 |
 | Yandex     | <https://yandex.com/images/search>   |
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Read in other languages: [简体中文](README.cn.md), [Русский](README.r
 | Google     | <https://www.google.com/imghp>       |
 | IQDB       | <https://iqdb.org/>                  |
 | SauceNAO   | <https://saucenao.com/>              |
+| Tineye     | <https://tineye.com/search/>         |
 | TraceMoe   | <https://trace.moe/>                 |
 | Yandex     | <https://yandex.com/images/search>   |
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -39,6 +39,7 @@
 | Google     | <https://www.google.com/imghp>       |
 | IQDB       | <https://iqdb.org/>                  |
 | SauceNAO   | <https://saucenao.com/>              |
+| Tineye     | <https://tineye.com/search/>         |
 | TraceMoe   | <https://trace.moe/>                 |
 | Yandex     | <https://yandex.com/images/search>   |
 

--- a/demo/code/ascii2d.py
+++ b/demo/code/ascii2d.py
@@ -1,24 +1,20 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Ascii2D, Network
 from PicImageSearch.model import Ascii2DResponse
 from PicImageSearch.sync import Ascii2D as Ascii2DSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
 base_url = "https://ascii2d.net"
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test01.jpg"
-file = Path(__file__).parent.parent / "images" / "test01.jpg"
+url = f"{IMAGE_BASE_URL}/test01.jpg"
+file = get_image_path("test01.jpg")
 bovw = False  # Use feature search or not
 verify_ssl = True  # Whether to verify SSL certificates or not
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies, verify_ssl=verify_ssl) as client:
+    async with Network(proxies=PROXIES, verify_ssl=verify_ssl) as client:
         ascii2d = Ascii2D(base_url=base_url, bovw=bovw, client=client)
         # resp = await ascii2d.search(url=url)
         resp = await ascii2d.search(file=file)
@@ -27,7 +23,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    ascii2d = Ascii2DSync(base_url=base_url, bovw=bovw, proxies=proxies, verify_ssl=verify_ssl)
+    ascii2d = Ascii2DSync(base_url=base_url, bovw=bovw, proxies=PROXIES, verify_ssl=verify_ssl)
     resp = ascii2d.search(url=url)
     # resp = ascii2d.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/ascii2d.py
+++ b/demo/code/ascii2d.py
@@ -23,7 +23,12 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    ascii2d = Ascii2DSync(base_url=base_url, bovw=bovw, proxies=PROXIES, verify_ssl=verify_ssl)
+    ascii2d = Ascii2DSync(
+        base_url=base_url,
+        bovw=bovw,
+        proxies=PROXIES,
+        verify_ssl=verify_ssl,
+    )
     resp = ascii2d.search(url=url)
     # resp = ascii2d.search(file=file)
     show_result(resp)  # type: ignore
@@ -46,5 +51,5 @@ def show_result(resp: Ascii2DResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/baidu.py
+++ b/demo/code/baidu.py
@@ -38,5 +38,5 @@ def show_result(resp: BaiDuResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/baidu.py
+++ b/demo/code/baidu.py
@@ -1,21 +1,17 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import BaiDu, Network
 from PicImageSearch.model import BaiDuResponse
 from PicImageSearch.sync import BaiDu as BaiDuSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test02.jpg"
-file = Path(__file__).parent.parent / "images" / "test02.jpg"
+url = f"{IMAGE_BASE_URL}/test02.jpg"
+file = get_image_path("test02.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         baidu = BaiDu(client=client)
         # resp = await baidu.search(url=url)
         resp = await baidu.search(file=file)
@@ -24,7 +20,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    baidu = BaiDuSync(proxies=proxies)
+    baidu = BaiDuSync(proxies=PROXIES)
     resp = baidu.search(url=url)
     # resp = baidu.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/bing.py
+++ b/demo/code/bing.py
@@ -1,22 +1,18 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Bing, Network
 from PicImageSearch.model import BingResponse
 from PicImageSearch.sync import Bing as BingSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
 http2 = True
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test08.jpg"
-file = Path(__file__).parent.parent / "images" / "test08.jpg"
+url = f"{IMAGE_BASE_URL}/test08.jpg"
+file = get_image_path("test08.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies, http2=http2) as client:
+    async with Network(proxies=PROXIES, http2=http2) as client:
         bing = Bing(client=client)
         # resp = await bing.search(url=url)
         resp = await bing.search(file=file)
@@ -25,7 +21,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    bing = BingSync(proxies=proxies, http2=http2)
+    bing = BingSync(proxies=PROXIES, http2=http2)
     resp = bing.search(url=url)
     # resp = bing.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/bing.py
+++ b/demo/code/bing.py
@@ -32,27 +32,27 @@ def show_result(resp: BingResponse) -> None:
 
     if resp.pages_including:
         logger.info("Pages Including:")
-        for item in resp.pages_including:
-            logger.info(f"  Name: {item.name}")
-            logger.info(f"  URL: {item.url}")
-            logger.info(f"  Thumbnail URL: {item.thumbnail}")
-            logger.info(f"  Image URL: {item.image_url}")
+        for page_item in resp.pages_including:
+            logger.info(f"  Name: {page_item.name}")
+            logger.info(f"  URL: {page_item.url}")
+            logger.info(f"  Thumbnail URL: {page_item.thumbnail}")
+            logger.info(f"  Image URL: {page_item.image_url}")
             logger.info("-" * 20)
 
     if resp.visual_search:
         logger.info("Visual Search:")
-        for item in resp.visual_search:
-            logger.info(f"  Name: {item.name}")
-            logger.info(f"  URL: {item.url}")
-            logger.info(f"  Thumbnail URL: {item.thumbnail}")
-            logger.info(f"  Image URL: {item.image_url}")
+        for visual_item in resp.visual_search:
+            logger.info(f"  Name: {visual_item.name}")
+            logger.info(f"  URL: {visual_item.url}")
+            logger.info(f"  Thumbnail URL: {visual_item.thumbnail}")
+            logger.info(f"  Image URL: {visual_item.image_url}")
             logger.info("-" * 20)
 
     if resp.related_searches:
         logger.info("Related Searches:")
-        for item in resp.related_searches:
-            logger.info(f"  Text: {item.text}")
-            logger.info(f"  Thumbnail URL: {item.thumbnail}")
+        for search_item in resp.related_searches:
+            logger.info(f"  Text: {search_item.text}")
+            logger.info(f"  Thumbnail URL: {search_item.thumbnail}")
             logger.info("-" * 20)
 
     if resp.travel:
@@ -102,5 +102,5 @@ def show_result(resp: BingResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/config.py
+++ b/demo/code/config.py
@@ -6,7 +6,9 @@ from loguru import logger
 USE_SIMPLE_LOGGER = True
 PROXIES = "http://127.0.0.1:1080"
 # PROXIES = None
-IMAGE_BASE_URL = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images"
+IMAGE_BASE_URL = (
+    "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images"
+)
 
 if USE_SIMPLE_LOGGER:
     logger.remove()
@@ -15,5 +17,6 @@ if USE_SIMPLE_LOGGER:
 
 def get_image_path(image_name: str) -> Path:
     return Path(__file__).parent.parent / "images" / image_name
+
 
 __all__ = ["IMAGE_BASE_URL", "PROXIES", "get_image_path", "logger"]

--- a/demo/code/config.py
+++ b/demo/code/config.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+from loguru import logger
+
+USE_SIMPLE_LOGGER = True
+PROXIES = "http://127.0.0.1:1080"
+# PROXIES = None
+IMAGE_BASE_URL = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images"
+
+if USE_SIMPLE_LOGGER:
+    logger.remove()
+    logger.add(sys.stderr, format="<level>{level: <8}</level> <green>{message}</green>")
+
+
+def get_image_path(image_name: str) -> Path:
+    return Path(__file__).parent.parent / "images" / image_name
+
+__all__ = ["IMAGE_BASE_URL", "PROXIES", "get_image_path", "logger"]

--- a/demo/code/copyseeker.py
+++ b/demo/code/copyseeker.py
@@ -1,23 +1,17 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Copyseeker, Network
 from PicImageSearch.model import CopyseekerResponse
 from PicImageSearch.sync import Copyseeker as CopyseekerSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = (
-    "https://github.com/kitUIN/PicImageSearch/blob/main/demo/images/test05.jpg?raw=true"
-)
-file = Path(__file__).parent.parent / "images" / "test05.jpg"
+url = f"{IMAGE_BASE_URL}/test05.jpg"
+file = get_image_path("test05.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         copyseeker = Copyseeker(client=client)
         # resp = await copyseeker.search(url=url)
         resp = await copyseeker.search(file=file)
@@ -26,7 +20,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    copyseeker = CopyseekerSync(proxies=proxies)
+    copyseeker = CopyseekerSync(proxies=PROXIES)
     resp = copyseeker.search(url=url)
     # resp = copyseeker.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/copyseeker.py
+++ b/demo/code/copyseeker.py
@@ -45,5 +45,5 @@ def show_result(resp: CopyseekerResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/ehentai.py
+++ b/demo/code/ehentai.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 
 from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import EHentai, Network
@@ -9,7 +10,7 @@ url = f"{IMAGE_BASE_URL}/test06.jpg"
 file = get_image_path("test06.jpg")
 
 # Note: EXHentai search requires cookies if to be used
-cookies = None
+cookies: Optional[str] = None
 
 # Use EXHentai search or not, it's recommended to use bool(cookies), i.e. use EXHentai search if cookies is configured
 is_ex = False
@@ -56,5 +57,5 @@ def show_result(resp: EHentaiResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/ehentai.py
+++ b/demo/code/ehentai.py
@@ -1,16 +1,12 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import EHentai, Network
 from PicImageSearch.model import EHentaiResponse
 from PicImageSearch.sync import EHentai as EHentaiSync
 
-proxies = "http://127.0.0.1:1080"
-# proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test06.jpg"
-file = Path(__file__).parent.parent / "images" / "test06.jpg"
+url = f"{IMAGE_BASE_URL}/test06.jpg"
+file = get_image_path("test06.jpg")
 
 # Note: EXHentai search requires cookies if to be used
 cookies = None
@@ -24,7 +20,7 @@ timeout = 60
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies, cookies=cookies, timeout=timeout) as client:
+    async with Network(proxies=PROXIES, cookies=cookies, timeout=timeout) as client:
         ehentai = EHentai(is_ex=is_ex, client=client)
         # resp = await ehentai.search(url=url)
         resp = await ehentai.search(file=file)
@@ -35,7 +31,7 @@ async def test_async() -> None:
 def test_sync() -> None:
     ehentai = EHentaiSync(
         is_ex=is_ex,
-        proxies=proxies,
+        proxies=PROXIES,
         cookies=cookies,
         timeout=timeout,
     )

--- a/demo/code/google.py
+++ b/demo/code/google.py
@@ -33,9 +33,9 @@ def test_sync() -> None:
     show_result(resp)  # type: ignore
     resp2 = google.next_page(resp)  # type: ignore
     show_result(resp2)  # type: ignore
-    resp3 = google.pre_page(resp2)  # type: ignore
-    show_result(resp3)  # type: ignore
-    show_result(resp2)  # type: ignore
+    if resp2:
+        resp3 = google.pre_page(resp2)  # type: ignore
+        show_result(resp3)  # type: ignore
 
 
 def show_result(resp: Optional[GoogleResponse]) -> None:
@@ -57,5 +57,5 @@ def show_result(resp: Optional[GoogleResponse]) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/google.py
+++ b/demo/code/google.py
@@ -1,23 +1,19 @@
 import asyncio
-from pathlib import Path
 from typing import Optional
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Google, Network
 from PicImageSearch.model import GoogleResponse
 from PicImageSearch.sync import Google as GoogleSync
 
-proxies = "http://127.0.0.1:1080"
-# proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test03.jpg"
-file = Path(__file__).parent.parent / "images" / "test03.jpg"
+url = f"{IMAGE_BASE_URL}/test03.jpg"
+file = get_image_path("test03.jpg")
 base_url = "https://www.google.co.jp"
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         google = Google(base_url=base_url, client=client)
         # resp = await google.search(url=url)
         resp = await google.search(file=file)
@@ -31,7 +27,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    google = GoogleSync(base_url=base_url, proxies=proxies)
+    google = GoogleSync(base_url=base_url, proxies=PROXIES)
     resp = google.search(url=url)
     # resp = google.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/iqdb.py
+++ b/demo/code/iqdb.py
@@ -46,5 +46,5 @@ def show_result(resp: IqdbResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/iqdb.py
+++ b/demo/code/iqdb.py
@@ -1,21 +1,17 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Iqdb, Network
 from PicImageSearch.model import IqdbResponse
 from PicImageSearch.sync import Iqdb as IqdbSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test01.jpg"
-file = Path(__file__).parent.parent / "images" / "test01.jpg"
+url = f"{IMAGE_BASE_URL}/test01.jpg"
+file = get_image_path("test01.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         iqdb = Iqdb(client=client)
         # resp = await iqdb.search(url=url)
         resp = await iqdb.search(file=file)
@@ -24,7 +20,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    iqdb = IqdbSync(proxies=proxies)
+    iqdb = IqdbSync(proxies=PROXIES)
     resp = iqdb.search(url=url)
     # resp = iqdb.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/iqdb_3d.py
+++ b/demo/code/iqdb_3d.py
@@ -42,5 +42,5 @@ def show_result(resp: IqdbResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/iqdb_3d.py
+++ b/demo/code/iqdb_3d.py
@@ -1,21 +1,17 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Iqdb, Network
 from PicImageSearch.model import IqdbResponse
 from PicImageSearch.sync import Iqdb as IqdbSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test04.jpg"
-file = Path(__file__).parent.parent / "images" / "test04.jpg"
+url = f"{IMAGE_BASE_URL}/test04.jpg"
+file = get_image_path("test04.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         iqdb = Iqdb(is_3d=True, client=client)
         # resp = await iqdb.search(url=url)
         resp = await iqdb.search(file=file)
@@ -24,7 +20,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    iqdb = IqdbSync(is_3d=True, proxies=proxies)
+    iqdb = IqdbSync(is_3d=True, proxies=PROXIES)
     resp = iqdb.search(url=url)
     # resp = iqdb.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/saucenao.py
+++ b/demo/code/saucenao.py
@@ -1,22 +1,18 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Network, SauceNAO
 from PicImageSearch.model import SauceNAOResponse
 from PicImageSearch.sync import SauceNAO as SauceNAOSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test01.jpg"
-file = Path(__file__).parent.parent / "images" / "test01.jpg"
+url = f"{IMAGE_BASE_URL}/test01.jpg"
+file = get_image_path("test01.jpg")
 api_key = "a4ab3f81009b003528f7e31aed187fa32a063f58"
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         saucenao = SauceNAO(api_key=api_key, hide=3, client=client)
         # resp = await saucenao.search(url=url)
         resp = await saucenao.search(file=file)
@@ -25,7 +21,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    saucenao = SauceNAOSync(api_key=api_key, hide=3, proxies=proxies)
+    saucenao = SauceNAOSync(api_key=api_key, hide=3, proxies=PROXIES)
     resp = saucenao.search(url=url)
     # resp = saucenao.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/saucenao.py
+++ b/demo/code/saucenao.py
@@ -47,5 +47,5 @@ def show_result(resp: SauceNAOResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/tineye.py
+++ b/demo/code/tineye.py
@@ -1,0 +1,91 @@
+import asyncio
+import mimetypes
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+
+from PicImageSearch import Network, Tineye
+from PicImageSearch.model import TineyeResponse
+from PicImageSearch.sync import Tineye as TineyeSync
+
+# proxies = "http://127.0.0.1:1080"
+proxies = None
+url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test02.jpg"
+file = Path(__file__).parent.parent / "images" / "test07.jpg"
+
+# TinEye search parameters
+show_unavailable_domains = False # Example: show_unavailable_domains=True
+domain = ""  # Example: domain='wikipedia.org'
+tags = ""  # Example: tags="stock,collection"
+sort = "score"  # Example: "size" or "crawl_date"
+order = "desc" # Example: "asc"
+
+
+@logger.catch()
+async def test_async() -> None:
+    async with Network(proxies=proxies) as client:
+        tineye = Tineye(client=client)
+        # resp = await tineye.search(url=url, show_unavailable_domains=show_unavailable_domains, domain=domain, tags=tags, sort=sort, order=order)
+        resp = await tineye.search(file=file, show_unavailable_domains=show_unavailable_domains, domain=domain, tags=tags, sort=sort, order=order)
+        show_result(resp, "Initial Search")
+
+        if resp.pages and len(resp.pages) > 1:  # type: ignore
+            resp2 = await tineye.next_page(resp)  # type: ignore
+            show_result(resp2, "Next Page (Async)")
+
+            if resp2:
+                resp3 = await tineye.next_page(resp2)  # type: ignore
+                show_result(resp3, "Next Page (Async)")
+
+                if resp3:
+                    resp4 = await tineye.pre_page(resp3)  # type: ignore
+                    show_result(resp4, "Previous Page (Async)")
+
+
+@logger.catch()
+def test_sync() -> None:
+    tineye = TineyeSync(proxies=proxies)
+    resp = tineye.search(url=url, show_unavailable_domains=show_unavailable_domains, domain=domain, tags=tags, sort=sort, order=order)
+    # resp = tineye.search(file=file)
+    show_result(resp, "Initial Search (Sync)")
+
+    if resp.pages and len(resp.pages) > 1:  # type: ignore
+        resp2 = tineye.next_page(resp)  # type: ignore
+        show_result(resp2, "Next Page (Sync)")
+
+        if resp2:
+            resp3 = tineye.next_page(resp2)  # type: ignore
+            show_result(resp3, "Next Page (Sync)")
+
+            if resp3:
+                resp4 = tineye.pre_page(resp3)  # type: ignore
+                show_result(resp4, "Previous Page (Sync)")
+
+
+def show_result(resp: Optional[TineyeResponse], title: str = "") -> None:
+    if not resp or not resp.raw:
+        logger.info(f"{title}: No results found.")
+        return
+    # logger.info(f"Domains: {resp.domains}")
+    logger.info(f"{title}:")
+    logger.info(f"  Status Code: {resp.status_code}")
+    logger.info(f"  Query Hash: {resp.query_hash}") # image hash
+    logger.info(f"  Total Pages: {len(resp.pages)}")  # type: ignore
+    logger.info(f"  Current Page: {resp.page_number}")
+    logger.info(f"  Results:")
+
+    for i, item in enumerate(resp.raw):
+        logger.info(f"    Match {i + 1}:")
+        logger.info(f"      Thumbnail URL: {item.thumbnail}")
+        logger.info(f"      Image URL: {item.image_url}")
+        logger.info(f"      URL(Backlink): {item.url}")
+        logger.info(f"      Domain: {item.domain}")
+        logger.info(f"      Size: {item.size[0]}x{item.size[1]}")
+        logger.info(f"      Crawl Date: {item.crawl_date}")
+        logger.info("-" * 40)
+
+
+if __name__ == "__main__":
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/tineye.py
+++ b/demo/code/tineye.py
@@ -1,66 +1,89 @@
 import asyncio
-import mimetypes
-from pathlib import Path
 from typing import Optional
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Network, Tineye
 from PicImageSearch.model import TineyeResponse
 from PicImageSearch.sync import Tineye as TineyeSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test02.jpg"
-file = Path(__file__).parent.parent / "images" / "test07.jpg"
+url = f"{IMAGE_BASE_URL}/test07.jpg"
+file = get_image_path("test07.jpg")
 
 # TinEye search parameters
-show_unavailable_domains = False # Example: show_unavailable_domains=True
+show_unavailable_domains = False
 domain = ""  # Example: domain='wikipedia.org'
 tags = ""  # Example: tags="stock,collection"
 sort = "score"  # Example: "size" or "crawl_date"
-order = "desc" # Example: "asc"
+order = "desc"  # Example: "asc"
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         tineye = Tineye(client=client)
-        # resp = await tineye.search(url=url, show_unavailable_domains=show_unavailable_domains, domain=domain, tags=tags, sort=sort, order=order)
-        resp = await tineye.search(file=file, show_unavailable_domains=show_unavailable_domains, domain=domain, tags=tags, sort=sort, order=order)
+        # resp = await tineye.search(
+        #     url=url,
+        #     show_unavailable_domains=show_unavailable_domains,
+        #     domain=domain,
+        #     tags=tags,
+        #     sort=sort,
+        #     order=order,
+        # )
+        resp = await tineye.search(
+            file=file,
+            show_unavailable_domains=show_unavailable_domains,
+            domain=domain,
+            tags=tags,
+            sort=sort,
+            order=order,
+        )
         show_result(resp, "Initial Search")
 
-        if resp.pages and len(resp.pages) > 1:  # type: ignore
-            resp2 = await tineye.next_page(resp)  # type: ignore
-            show_result(resp2, "Next Page (Async)")
+        if resp.pages and len(resp.pages) > 1:
+            resp2 = await tineye.next_page(resp)
+            show_result(resp2, "Next Page")
 
             if resp2:
-                resp3 = await tineye.next_page(resp2)  # type: ignore
-                show_result(resp3, "Next Page (Async)")
+                resp3 = await tineye.next_page(resp2)
+                show_result(resp3, "Next Page")
 
                 if resp3:
-                    resp4 = await tineye.pre_page(resp3)  # type: ignore
-                    show_result(resp4, "Previous Page (Async)")
+                    resp4 = await tineye.pre_page(resp3)
+                    show_result(resp4, "Previous Page")
 
 
 @logger.catch()
 def test_sync() -> None:
-    tineye = TineyeSync(proxies=proxies)
-    resp = tineye.search(url=url, show_unavailable_domains=show_unavailable_domains, domain=domain, tags=tags, sort=sort, order=order)
-    # resp = tineye.search(file=file)
-    show_result(resp, "Initial Search (Sync)")
+    tineye = TineyeSync(proxies=PROXIES)
+    resp = tineye.search(
+        url=url,
+        show_unavailable_domains=show_unavailable_domains,
+        domain=domain,
+        tags=tags,
+        sort=sort,
+        order=order,
+    )
+    # resp = tineye.search(
+    #     file=file,
+    #     show_unavailable_domains=show_unavailable_domains,
+    #     domain=domain,
+    #     tags=tags,
+    #     sort=sort,
+    #     order=order,
+    # )
+    show_result(resp, "Initial Search")  # type: ignore
 
     if resp.pages and len(resp.pages) > 1:  # type: ignore
         resp2 = tineye.next_page(resp)  # type: ignore
-        show_result(resp2, "Next Page (Sync)")
+        show_result(resp2, "Next Page")  # type: ignore
 
         if resp2:
             resp3 = tineye.next_page(resp2)  # type: ignore
-            show_result(resp3, "Next Page (Sync)")
+            show_result(resp3, "Next Page")  # type: ignore
 
             if resp3:
                 resp4 = tineye.pre_page(resp3)  # type: ignore
-                show_result(resp4, "Previous Page (Sync)")
+                show_result(resp4, "Previous Page")  # type: ignore
 
 
 def show_result(resp: Optional[TineyeResponse], title: str = "") -> None:
@@ -70,22 +93,26 @@ def show_result(resp: Optional[TineyeResponse], title: str = "") -> None:
     # logger.info(f"Domains: {resp.domains}")
     logger.info(f"{title}:")
     logger.info(f"  Status Code: {resp.status_code}")
-    logger.info(f"  Query Hash: {resp.query_hash}") # image hash
+    logger.info(f"  Query Hash: {resp.query_hash}")  # image hash
     logger.info(f"  Total Pages: {len(resp.pages)}")  # type: ignore
     logger.info(f"  Current Page: {resp.page_number}")
-    logger.info(f"  Results:")
+    logger.info("  Results:")
 
     for i, item in enumerate(resp.raw):
-        logger.info(f"    Match {i + 1}:")
-        logger.info(f"      Thumbnail URL: {item.thumbnail}")
-        logger.info(f"      Image URL: {item.image_url}")
-        logger.info(f"      URL(Backlink): {item.url}")
-        logger.info(f"      Domain: {item.domain}")
-        logger.info(f"      Size: {item.size[0]}x{item.size[1]}")
-        logger.info(f"      Crawl Date: {item.crawl_date}")
-        logger.info("-" * 40)
+        show_match_details(i, item)
+
+
+def show_match_details(match_index: int, match_item) -> None:
+    logger.info(f"    Match {match_index + 1}:")
+    logger.info(f"      Thumbnail URL: {match_item.thumbnail}")
+    logger.info(f"      Image URL: {match_item.image_url}")
+    logger.info(f"      URL(Backlink): {match_item.url}")
+    logger.info(f"      Domain: {match_item.domain}")
+    logger.info(f"      Size: {match_item.size[0]}x{match_item.size[1]}")
+    logger.info(f"      Crawl Date: {match_item.crawl_date}")
+    logger.info("-" * 50)
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())
-    # test_sync()
+    asyncio.run(test_async())  # type: ignore
+    # test_sync()  # type: ignore

--- a/demo/code/tineye.py
+++ b/demo/code/tineye.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Network, Tineye
-from PicImageSearch.model import TineyeResponse
+from PicImageSearch.model import TineyeItem, TineyeResponse
 from PicImageSearch.sync import Tineye as TineyeSync
 
 url = f"{IMAGE_BASE_URL}/test07.jpg"
@@ -39,7 +39,7 @@ async def test_async() -> None:
         )
         show_result(resp, "Initial Search")
 
-        if resp.pages and len(resp.pages) > 1:
+        if resp.total_pages > 1:
             resp2 = await tineye.next_page(resp)
             show_result(resp2, "Next Page")
 
@@ -73,7 +73,7 @@ def test_sync() -> None:
     # )
     show_result(resp, "Initial Search")  # type: ignore
 
-    if resp.pages and len(resp.pages) > 1:  # type: ignore
+    if resp.total_pages > 1:  # type: ignore
         resp2 = tineye.next_page(resp)  # type: ignore
         show_result(resp2, "Next Page")  # type: ignore
 
@@ -87,6 +87,9 @@ def test_sync() -> None:
 
 
 def show_result(resp: Optional[TineyeResponse], title: str = "") -> None:
+    if resp and not resp.raw:
+        logger.info(f"Origin Response: {resp.origin}")
+
     if not resp or not resp.raw:
         logger.info(f"{title}: No results found.")
         return
@@ -94,7 +97,7 @@ def show_result(resp: Optional[TineyeResponse], title: str = "") -> None:
     logger.info(f"{title}:")
     logger.info(f"  Status Code: {resp.status_code}")
     logger.info(f"  Query Hash: {resp.query_hash}")  # image hash
-    logger.info(f"  Total Pages: {len(resp.pages)}")  # type: ignore
+    logger.info(f"  Total Pages: {resp.total_pages}")
     logger.info(f"  Current Page: {resp.page_number}")
     logger.info("  Results:")
 
@@ -102,7 +105,7 @@ def show_result(resp: Optional[TineyeResponse], title: str = "") -> None:
         show_match_details(i, item)
 
 
-def show_match_details(match_index: int, match_item) -> None:
+def show_match_details(match_index: int, match_item: TineyeItem) -> None:
     logger.info(f"    Match {match_index + 1}:")
     logger.info(f"      Thumbnail URL: {match_item.thumbnail}")
     logger.info(f"      Image URL: {match_item.image_url}")
@@ -114,5 +117,5 @@ def show_match_details(match_index: int, match_item) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/tracemoe.py
+++ b/demo/code/tracemoe.py
@@ -54,5 +54,5 @@ def show_result(resp: TraceMoeResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    test_sync()

--- a/demo/code/tracemoe.py
+++ b/demo/code/tracemoe.py
@@ -1,21 +1,17 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Network, TraceMoe
 from PicImageSearch.model import TraceMoeResponse
 from PicImageSearch.sync import TraceMoe as TraceMoeSync
 
-# proxies = "http://127.0.0.1:1080"
-proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test05.jpg"
-file = Path(__file__).parent.parent / "images" / "test05.jpg"
+url = f"{IMAGE_BASE_URL}/test05.jpg"
+file = get_image_path("test05.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         tracemoe = TraceMoe(mute=False, size=None, client=client)
         # resp = await tracemoe.search(url=url)
         resp = await tracemoe.search(file=file)
@@ -24,7 +20,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    tracemoe = TraceMoeSync(mute=False, size=None, proxies=proxies)
+    tracemoe = TraceMoeSync(mute=False, size=None, proxies=PROXIES)
     resp = tracemoe.search(url=url)
     # resp = tracemoe.search(file=file)
     show_result(resp)  # type: ignore

--- a/demo/code/yandex.py
+++ b/demo/code/yandex.py
@@ -40,5 +40,5 @@ def show_result(resp: YandexResponse) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test_async())  # type: ignore
-    # test_sync()  # type: ignore
+    asyncio.run(test_async())
+    # test_sync()

--- a/demo/code/yandex.py
+++ b/demo/code/yandex.py
@@ -1,21 +1,17 @@
 import asyncio
-from pathlib import Path
 
-from loguru import logger
-
+from demo.code.config import IMAGE_BASE_URL, PROXIES, get_image_path, logger
 from PicImageSearch import Network, Yandex
 from PicImageSearch.model import YandexResponse
 from PicImageSearch.sync import Yandex as YandexSync
 
-proxies = "http://127.0.0.1:1080"
-# proxies = None
-url = "https://raw.githubusercontent.com/kitUIN/PicImageSearch/main/demo/images/test06.jpg"
-file = Path(__file__).parent.parent / "images" / "test06.jpg"
+url = f"{IMAGE_BASE_URL}/test06.jpg"
+file = get_image_path("test06.jpg")
 
 
 @logger.catch()
 async def test_async() -> None:
-    async with Network(proxies=proxies) as client:
+    async with Network(proxies=PROXIES) as client:
         yandex = Yandex(client=client)
         # resp = await yandex.search(url=url)
         resp = await yandex.search(file=file)
@@ -24,7 +20,7 @@ async def test_async() -> None:
 
 @logger.catch()
 def test_sync() -> None:
-    yandex = YandexSync(proxies=proxies)
+    yandex = YandexSync(proxies=PROXIES)
     resp = yandex.search(url=url)
     # resp = yandex.search(file=file)
     show_result(resp)  # type: ignore


### PR DESCRIPTION
Parser operation principle:
1. Sends a POST request to https://tineye.com/api/v1/result_json/
2. To obtain result domains (for subsequent filtering search, for example), uses https://tineye.com/api/v1/search/get_domains/

In total, two initial requests

Since the page only shows 10 results, and there might be many pages, a `next_page` (and `pre_page`) function was created that sends a get request to the next page to retrieve results. If we were using the official API, we could set the limit to 0, but no matter how I tried, this is an unchangeable parameter when manually parsing.

P.S. Regarding new engines. I couldn't find any new more or less decent engines, and most likely they simply don't exist, so I probably won't be adding new ones in the near future. Only stocks and trash sites remain. I think if someone needs a new engine, they will create an issue.