### PR TITLE
fix copyseeker request logic and network typeerror

### DIFF
--- a/PicImageSearch/engines/copyseeker.py
+++ b/PicImageSearch/engines/copyseeker.py
@@ -107,9 +107,13 @@ class Copyseeker(BaseSearchEngine[CopyseekerResponse]):
             return CopyseekerResponse({}, "")
 
         data = {"discoveryId": discovery_id, "hasBlocker": False}
-
+        headers = {
+            "Origin": "https://copyseeker.net",
+            "Referer": "https://copyseeker.net/"
+        }
+        
         resp = await self._make_request(
-            method="post", endpoint="OnProvideDiscovery", json=data
+            method="post", endpoint="OnProvideDiscovery", json=data, headers=headers
         )
         resp_json = json_loads(resp.text)
         return CopyseekerResponse(resp_json, resp.url)

--- a/PicImageSearch/network.py
+++ b/PicImageSearch/network.py
@@ -60,7 +60,7 @@ class Network:
             cookies=self.cookies,
             verify=verify_ssl,
             http2=http2,
-            proxies=proxies,
+            proxy=proxies,
             timeout=timeout,
             follow_redirects=True,
         )


### PR DESCRIPTION
fix copyseeker request logic
added headers to fix error
before:
`{
    "id": "FORBIDDEN",
    "imageUrl": null,
    "bestGuessLabel": null,
    "entities": null,
    "totalLinksFound": 0,
    "exif": null,
    "pages": [],
    "visuallySimilarImages": []
}`

after:
`*normal response*`


fix network TypeError
fixed `TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'`